### PR TITLE
Fix MaxPathLen to -1 due to the specification change of go1.15.

### DIFF
--- a/main.go
+++ b/main.go
@@ -244,8 +244,7 @@ func (ctx *DevProxy) prepareMITMCertificate(hosts []string) (*tls.Certificate, e
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 		IsCA:                  false,
-		MaxPathLen:            0,
-		MaxPathLenZero:        true,
+		MaxPathLen:            -1,
 		DNSNames:              hosts,
 	}
 	derBytes, err := x509.CreateCertificate(ctx.CryptoRandReader, &template, ca.Certificate, ca.Certificate.PublicKey, ca.PrivateKey)


### PR DESCRIPTION
Fix MaxPathLen to -1 due to the specification change of go1.15.
see https://golang.org/doc/go1.15#crypto/x509