### PR TITLE
Fix MaxPathLen to -1 due to the specification change of go1.15.

### DIFF
--- a/main.go
+++ b/main.go
@@ -265,8 +265,7 @@ func (ctx *DevProxy) generateMITMCertificate(host string, sortedSans []string, n
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 		IsCA:                  false,
-		MaxPathLen:            0,
-		MaxPathLenZero:        true,
+		MaxPathLen:            -1,
 		DNSNames:              sortedSans,
 	}
 	derBytes, err := x509.CreateCertificate(ctx.CryptoRandReader, &template, ca.Certificate, ca.Certificate.PublicKey, ca.PrivateKey)


### PR DESCRIPTION
Fix MaxPathLen to -1 due to the specification change of go1.15.
see https://golang.org/doc/go1.15#crypto/x509