### PR TITLE
Fix the TLS validity period to be configurable

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -15,6 +15,7 @@ tls:
   ca:
     cert: testca.rsa.crt.pem
     key: testca.rsa.key.pem
+  validity: 397
   # MITM with prepared certificates
   prepared:
     - ^local\\.my-domain\\.example\\.com$:
@@ -39,7 +40,7 @@ hosts:
     - ^(/.*)$: http://localhost:8082$1
       # you can add arbitrary headers to every request that matches the pattern
       headers:
-        X-Forwarded-Proto: https  
+        X-Forwarded-Proto: https
   http://fastcgi.example.com:
     - ^(((?:/.*)*/[^/]+\.php)(/.*|$)): fastcgi://localhost$1
       headers:

--- a/main.go
+++ b/main.go
@@ -238,7 +238,7 @@ func (ctx *DevProxy) generateMITMCertificate(host string, sortedSans []string, n
 	}
 	ctx.Logger.Debugf("CA: CN=%s", ca.Certificate.Subject.CommonName)
 	start := now.Add(-time.Minute)
-	end := now.Add(30 * 3600 * time.Hour)
+	end := now.Add(time.Duration(ctx.Config.MITM.ValidityPeriod) * 24 * time.Hour)
 
 	h := sha1.New()
 	for _, host := range sortedSans {


### PR DESCRIPTION
Fixed the TLS validity period to be configurable.
macOS and iOS need to shorten the validity period of trusted certificates.
