### PR TITLE
Allow Host header override

### DIFF
--- a/server.go
+++ b/server.go
@@ -617,6 +617,11 @@ func FilterRequest(perHostConfig *PerHostConfig, r *http.Request, proxyCtx *OurP
 		}
 		newRequest := r.Clone(r.Context())
 		newRequest.URL = newUrl
+		host := headerSets.Get("Host")
+		if host != "" {
+			newRequest.Host = host
+			headerSets.Del("Host")
+		}
 		for headerName, headers := range headerSets {
 			if headers == nil {
 				delete(newRequest.Header, headerName)


### PR DESCRIPTION
It's my bad that `Host` header should have been set to `Host` field in place of `Header`.